### PR TITLE
SHA3 API Proposal

### DIFF
--- a/SHA3.cs
+++ b/SHA3.cs
@@ -1,0 +1,191 @@
+namespace System.Security.Cryptography;
+
+public partial struct HashAlgorithmName {
+    public static HashAlgorithmName SHA3_256 { get; }
+    public static HashAlgorithmName SHA3_384 { get; }
+    public static HashAlgorithmName SHA3_512 { get; }
+}
+
+public sealed partial class RSAEncryptionPadding {
+    public static RSAEncryptionPadding OaepSHA3_256 { get; }
+    public static RSAEncryptionPadding OaepSHA3_384 { get; }
+    public static RSAEncryptionPadding OaepSHA3_512 { get; }
+}
+
+public abstract partial class SHA3_256 : HashAlgorithm {
+    public const int HashSizeInBits = 256;
+    public const int HashSizeInBytes = 32;
+
+    protected SHA3_256();
+
+    public static bool IsSupported { get; }
+
+    public static new SHA3_256 Create();
+
+    public static byte[] HashData(byte[] source);
+    public static byte[] HashData(ReadOnlySpan<byte> source);
+    public static int HashData(ReadOnlySpan<byte> source, Span<byte> destination);
+    public static bool TryHashData(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesWritten);
+
+    public static byte[] HashData(Stream source);
+    public static int HashData(Stream source, Span<byte> destination);
+    public static ValueTask<int> HashDataAsync(Stream source, Memory<byte> destination, CancellationToken cancellationToken = default);
+    public static ValueTask<byte[]> HashDataAsync(Stream source, CancellationToken cancellationToken = default);
+}
+
+
+public abstract partial class SHA3_384 : HashAlgorithm {
+    public const int HashSizeInBits = 384;
+    public const int HashSizeInBytes = 48;
+
+    protected SHA3_384();
+
+    public static bool IsSupported { get; }
+
+    public static new SHA3_384 Create();
+
+    public static byte[] HashData(byte[] source);
+    public static byte[] HashData(ReadOnlySpan<byte> source);
+    public static int HashData(ReadOnlySpan<byte> source, Span<byte> destination);
+    public static bool TryHashData(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesWritten);
+
+    public static byte[] HashData(Stream source);
+    public static int HashData(Stream source, Span<byte> destination);
+    public static ValueTask<int> HashDataAsync(Stream source, Memory<byte> destination, CancellationToken cancellationToken = default);
+    public static ValueTask<byte[]> HashDataAsync(Stream source, CancellationToken cancellationToken = default);
+}
+
+public abstract partial class SHA3_512 : HashAlgorithm {
+    public const int HashSizeInBits = 512;
+    public const int HashSizeInBytes = 64;
+
+    protected SHA3_512();
+
+    public static bool IsSupported { get; }
+
+    public static new SHA3_512 Create();
+
+    public static byte[] HashData(byte[] source);
+    public static byte[] HashData(ReadOnlySpan<byte> source);
+    public static int HashData(ReadOnlySpan<byte> source, Span<byte> destination);
+    public static bool TryHashData(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesWritten);
+
+    public static byte[] HashData(Stream source);
+    public static int HashData(Stream source, Span<byte> destination);
+    public static ValueTask<int> HashDataAsync(Stream source, Memory<byte> destination, CancellationToken cancellationToken = default);
+    public static ValueTask<byte[]> HashDataAsync(Stream source, CancellationToken cancellationToken = default);
+}
+
+
+public partial class HMACSHA3_256 : HMAC {
+    public const int HashSizeInBits = 256;
+    public const int HashSizeInBytes = 32;
+
+    public HMACSHA3_256();
+    public HMACSHA3_256(byte[] key);
+
+    public static bool IsSupported { get; } // New
+
+    public static byte[] HashData(byte[] key, byte[] source);
+    public static byte[] HashData(ReadOnlySpan<byte> key, ReadOnlySpan<byte> source);
+    public static int HashData(ReadOnlySpan<byte> key, ReadOnlySpan<byte> source, Span<byte> destination);
+    public static bool TryHashData(ReadOnlySpan<byte> key, ReadOnlySpan<byte> source, Span<byte> destination, out int bytesWritten);
+
+    public static byte[] HashData(byte[] key, Stream source);
+    public static byte[] HashData(ReadOnlySpan<byte> key, Stream source);
+    public static int HashData(ReadOnlySpan<byte> key, Stream source, Span<byte> destination);
+
+    public static ValueTask<byte[]> HashDataAsync(byte[] key, Stream source, CancellationToken cancellationToken = default);
+    public static ValueTask<int> HashDataAsync(ReadOnlyMemory<byte> key, Stream source, Memory<byte> destination, CancellationToken cancellationToken = default);
+    public static ValueTask<byte[]> HashDataAsync(ReadOnlyMemory<byte> key, Stream source, CancellationToken cancellationToken = default);
+}
+
+public partial class HMACSHA3_384 : HMAC {
+    public const int HashSizeInBits = 384;
+    public const int HashSizeInBytes = 48;
+
+    public HMACSHA3_384();
+    public HMACSHA3_384(byte[] key);
+
+    public static bool IsSupported { get; } // New
+
+    public static byte[] HashData(byte[] key, byte[] source);
+    public static byte[] HashData(ReadOnlySpan<byte> key, ReadOnlySpan<byte> source);
+    public static int HashData(ReadOnlySpan<byte> key, ReadOnlySpan<byte> source, Span<byte> destination);
+    public static bool TryHashData(ReadOnlySpan<byte> key, ReadOnlySpan<byte> source, Span<byte> destination, out int bytesWritten);
+
+    public static byte[] HashData(byte[] key, Stream source);
+    public static byte[] HashData(ReadOnlySpan<byte> key, Stream source);
+    public static int HashData(ReadOnlySpan<byte> key, Stream source, Span<byte> destination);
+
+    public static ValueTask<byte[]> HashDataAsync(byte[] key, Stream source, CancellationToken cancellationToken = default);
+    public static ValueTask<int> HashDataAsync(ReadOnlyMemory<byte> key, Stream source, Memory<byte> destination, CancellationToken cancellationToken = default);
+    public static ValueTask<byte[]> HashDataAsync(ReadOnlyMemory<byte> key, Stream source, CancellationToken cancellationToken = default);
+}
+
+public partial class HMACSHA3_512 : HMAC {
+    public const int HashSizeInBits = 512;
+    public const int HashSizeInBytes = 64;
+
+    public HMACSHA3_512();
+    public HMACSHA3_512(byte[] key);
+
+    public static bool IsSupported { get; } // New
+
+    public static byte[] HashData(byte[] key, byte[] source);
+    public static byte[] HashData(ReadOnlySpan<byte> key, ReadOnlySpan<byte> source);
+    public static int HashData(ReadOnlySpan<byte> key, ReadOnlySpan<byte> source, Span<byte> destination);
+    public static bool TryHashData(ReadOnlySpan<byte> key, ReadOnlySpan<byte> source, Span<byte> destination, out int bytesWritten);
+
+    public static byte[] HashData(byte[] key, Stream source);
+    public static byte[] HashData(ReadOnlySpan<byte> key, Stream source);
+    public static int HashData(ReadOnlySpan<byte> key, Stream source, Span<byte> destination);
+
+    public static ValueTask<byte[]> HashDataAsync(byte[] key, Stream source, CancellationToken cancellationToken = default);
+    public static ValueTask<int> HashDataAsync(ReadOnlyMemory<byte> key, Stream source, Memory<byte> destination, CancellationToken cancellationToken = default);
+    public static ValueTask<byte[]> HashDataAsync(ReadOnlyMemory<byte> key, Stream source, CancellationToken cancellationToken = default);
+}
+
+public abstract partial class Shake : IDisposable {
+    internal Shake(); // Will not be subclassable by developers.
+
+    public void AppendData(byte[] data);
+    public void AppendData(ReadOnlySpan<byte> data);
+
+    public byte[] GetCurrentHash(int outputLength);
+    public void GetCurrentHash(Span<byte> destination);
+    public byte[] GetHashAndReset(int outputLength);
+    public void GetHashAndReset(Span<byte> destination);
+
+    public void Dispose();
+}
+
+public sealed partial class Shake128 : Shake {
+    public Shake128();
+
+    public static bool IsSupported { get; }
+
+    public static byte[] HashData(byte[] source, int outputLength);
+    public static byte[] HashData(ReadOnlySpan<byte> source, int outputLength);
+    public static void HashData(ReadOnlySpan<byte> source, Span<byte> destination);
+
+    public static byte[] HashData(Stream source, int outputLength);
+    public static void HashData(Stream source, Span<byte> destination);
+    public static ValueTask HashDataAsync(Stream source, Memory<byte> destination, CancellationToken cancellationToken = default);
+    public static ValueTask<byte[]> HashDataAsync(Stream source, int outputLength, CancellationToken cancellationToken = default);
+}
+
+public sealed partial class Shake256 : Shake {
+    public Shake256();
+
+    public static bool IsSupported { get; }
+
+    public static byte[] HashData(byte[] source, int outputLength);
+    public static byte[] HashData(ReadOnlySpan<byte> source, int outputLength);
+    public static void HashData(ReadOnlySpan<byte> source, Span<byte> destination);
+
+    public static byte[] HashData(Stream source, int outputLength);
+    public static void HashData(Stream source, Span<byte> destination);
+    public static ValueTask HashDataAsync(Stream source, Memory<byte> destination, CancellationToken cancellationToken = default);
+    public static ValueTask<byte[]> HashDataAsync(Stream source, int outputLength, CancellationToken cancellationToken = default);
+}

--- a/SHA3.cs
+++ b/SHA3.cs
@@ -584,13 +584,13 @@ public abstract partial class Shake : IDisposable {
     protected virtual void Dispose(bool disposing);
 }
 
+[UnsupportedOSPlatform("ios")]
+[UnsupportedOSPlatform("tvos")]
+[UnsupportedOSPlatform("android")]
+[UnsupportedOSPlatform("browser")]
+[UnsupportedOSPlatform("osx")]
 public sealed partial class Shake128 : Shake {
 
-    [UnsupportedOSPlatform("ios")]
-    [UnsupportedOSPlatform("tvos")]
-    [UnsupportedOSPlatform("android")]
-    [UnsupportedOSPlatform("browser")]
-    [UnsupportedOSPlatform("osx")]
     public Shake128();
 
     [UnsupportedOSPlatformGuard("ios")]
@@ -600,63 +600,23 @@ public sealed partial class Shake128 : Shake {
     [UnsupportedOSPlatformGuard("osx")]
     public static bool IsSupported { get; }
 
-    [UnsupportedOSPlatform("ios")]
-    [UnsupportedOSPlatform("tvos")]
-    [UnsupportedOSPlatform("android")]
-    [UnsupportedOSPlatform("browser")]
-    [UnsupportedOSPlatform("osx")]
     public static byte[] HashData(byte[] source, int outputLength);
-
-    [UnsupportedOSPlatform("ios")]
-    [UnsupportedOSPlatform("tvos")]
-    [UnsupportedOSPlatform("android")]
-    [UnsupportedOSPlatform("browser")]
-    [UnsupportedOSPlatform("osx")]
     public static byte[] HashData(ReadOnlySpan<byte> source, int outputLength);
-
-    [UnsupportedOSPlatform("ios")]
-    [UnsupportedOSPlatform("tvos")]
-    [UnsupportedOSPlatform("android")]
-    [UnsupportedOSPlatform("browser")]
-    [UnsupportedOSPlatform("osx")]
     public static void HashData(ReadOnlySpan<byte> source, Span<byte> destination);
 
-    [UnsupportedOSPlatform("ios")]
-    [UnsupportedOSPlatform("tvos")]
-    [UnsupportedOSPlatform("android")]
-    [UnsupportedOSPlatform("browser")]
-    [UnsupportedOSPlatform("osx")]
     public static byte[] HashData(Stream source, int outputLength);
-
-    [UnsupportedOSPlatform("ios")]
-    [UnsupportedOSPlatform("tvos")]
-    [UnsupportedOSPlatform("android")]
-    [UnsupportedOSPlatform("browser")]
-    [UnsupportedOSPlatform("osx")]
     public static void HashData(Stream source, Span<byte> destination);
-
-    [UnsupportedOSPlatform("ios")]
-    [UnsupportedOSPlatform("tvos")]
-    [UnsupportedOSPlatform("android")]
-    [UnsupportedOSPlatform("browser")]
-    [UnsupportedOSPlatform("osx")]
     public static ValueTask HashDataAsync(Stream source, Memory<byte> destination, CancellationToken cancellationToken = default);
-
-    [UnsupportedOSPlatform("ios")]
-    [UnsupportedOSPlatform("tvos")]
-    [UnsupportedOSPlatform("android")]
-    [UnsupportedOSPlatform("browser")]
-    [UnsupportedOSPlatform("osx")]
     public static ValueTask<byte[]> HashDataAsync(Stream source, int outputLength, CancellationToken cancellationToken = default);
 }
 
+[UnsupportedOSPlatform("ios")]
+[UnsupportedOSPlatform("tvos")]
+[UnsupportedOSPlatform("android")]
+[UnsupportedOSPlatform("browser")]
+[UnsupportedOSPlatform("osx")]
 public sealed partial class Shake256 : Shake {
 
-    [UnsupportedOSPlatform("ios")]
-    [UnsupportedOSPlatform("tvos")]
-    [UnsupportedOSPlatform("android")]
-    [UnsupportedOSPlatform("browser")]
-    [UnsupportedOSPlatform("osx")]
     public Shake256();
 
     [UnsupportedOSPlatformGuard("ios")]
@@ -666,52 +626,12 @@ public sealed partial class Shake256 : Shake {
     [UnsupportedOSPlatformGuard("osx")]
     public static bool IsSupported { get; }
 
-    [UnsupportedOSPlatform("ios")]
-    [UnsupportedOSPlatform("tvos")]
-    [UnsupportedOSPlatform("android")]
-    [UnsupportedOSPlatform("browser")]
-    [UnsupportedOSPlatform("osx")]
     public static byte[] HashData(byte[] source, int outputLength);
-
-    [UnsupportedOSPlatform("ios")]
-    [UnsupportedOSPlatform("tvos")]
-    [UnsupportedOSPlatform("android")]
-    [UnsupportedOSPlatform("browser")]
-    [UnsupportedOSPlatform("osx")]
     public static byte[] HashData(ReadOnlySpan<byte> source, int outputLength);
-
-    [UnsupportedOSPlatform("ios")]
-    [UnsupportedOSPlatform("tvos")]
-    [UnsupportedOSPlatform("android")]
-    [UnsupportedOSPlatform("browser")]
-    [UnsupportedOSPlatform("osx")]
     public static void HashData(ReadOnlySpan<byte> source, Span<byte> destination);
 
-    [UnsupportedOSPlatform("ios")]
-    [UnsupportedOSPlatform("tvos")]
-    [UnsupportedOSPlatform("android")]
-    [UnsupportedOSPlatform("browser")]
-    [UnsupportedOSPlatform("osx")]
     public static byte[] HashData(Stream source, int outputLength);
-
-    [UnsupportedOSPlatform("ios")]
-    [UnsupportedOSPlatform("tvos")]
-    [UnsupportedOSPlatform("android")]
-    [UnsupportedOSPlatform("browser")]
-    [UnsupportedOSPlatform("osx")]
     public static void HashData(Stream source, Span<byte> destination);
-
-    [UnsupportedOSPlatform("ios")]
-    [UnsupportedOSPlatform("tvos")]
-    [UnsupportedOSPlatform("android")]
-    [UnsupportedOSPlatform("browser")]
-    [UnsupportedOSPlatform("osx")]
     public static ValueTask HashDataAsync(Stream source, Memory<byte> destination, CancellationToken cancellationToken = default);
-
-    [UnsupportedOSPlatform("ios")]
-    [UnsupportedOSPlatform("tvos")]
-    [UnsupportedOSPlatform("android")]
-    [UnsupportedOSPlatform("browser")]
-    [UnsupportedOSPlatform("osx")]
     public static ValueTask<byte[]> HashDataAsync(Stream source, int outputLength, CancellationToken cancellationToken = default);
 }

--- a/SHA3.cs
+++ b/SHA3.cs
@@ -18,19 +18,78 @@ public abstract partial class SHA3_256 : HashAlgorithm {
 
     protected SHA3_256();
 
+    [UnsupportedOSPlatformGuard("ios")]
+    [UnsupportedOSPlatformGuard("tvos")]
+    [UnsupportedOSPlatformGuard("android")]
+    [UnsupportedOSPlatformGuard("browser")]
+    [UnsupportedOSPlatformGuard("osx")]
     public static bool IsSupported { get; }
 
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("android")]
+    [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("osx")]
     public static new SHA3_256 Create();
 
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("android")]
+    [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("osx")]
     public static byte[] HashData(byte[] source);
+
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("android")]
+    [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("osx")]
     public static byte[] HashData(ReadOnlySpan<byte> source);
+
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("android")]
+    [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("osx")]
     public static int HashData(ReadOnlySpan<byte> source, Span<byte> destination);
+
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("android")]
+    [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("osx")]
     public static bool TryHashData(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesWritten);
 
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("android")]
+    [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("osx")]
     public static byte[] HashData(Stream source);
+
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("android")]
+    [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("osx")]
     public static int HashData(Stream source, Span<byte> destination);
-    public static ValueTask<int> HashDataAsync(Stream source, Memory<byte> destination, CancellationToken cancellationToken = default);
+
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("android")]
+    [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("osx")]
     public static ValueTask<byte[]> HashDataAsync(Stream source, CancellationToken cancellationToken = default);
+
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("android")]
+    [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("osx")]
+    public static ValueTask<int> HashDataAsync(
+        Stream source,
+        Memory<byte> destination,
+        CancellationToken cancellationToken = default);
 }
 
 
@@ -40,19 +99,78 @@ public abstract partial class SHA3_384 : HashAlgorithm {
 
     protected SHA3_384();
 
+    [UnsupportedOSPlatformGuard("ios")]
+    [UnsupportedOSPlatformGuard("tvos")]
+    [UnsupportedOSPlatformGuard("android")]
+    [UnsupportedOSPlatformGuard("browser")]
+    [UnsupportedOSPlatformGuard("osx")]
     public static bool IsSupported { get; }
 
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("android")]
+    [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("osx")]
     public static new SHA3_384 Create();
 
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("android")]
+    [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("osx")]
     public static byte[] HashData(byte[] source);
+
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("android")]
+    [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("osx")]
     public static byte[] HashData(ReadOnlySpan<byte> source);
+
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("android")]
+    [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("osx")]
     public static int HashData(ReadOnlySpan<byte> source, Span<byte> destination);
+
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("android")]
+    [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("osx")]
     public static bool TryHashData(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesWritten);
 
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("android")]
+    [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("osx")]
     public static byte[] HashData(Stream source);
+
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("android")]
+    [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("osx")]
     public static int HashData(Stream source, Span<byte> destination);
-    public static ValueTask<int> HashDataAsync(Stream source, Memory<byte> destination, CancellationToken cancellationToken = default);
+
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("android")]
+    [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("osx")]
     public static ValueTask<byte[]> HashDataAsync(Stream source, CancellationToken cancellationToken = default);
+
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("android")]
+    [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("osx")]
+    public static ValueTask<int> HashDataAsync(
+        Stream source,
+        Memory<byte> destination,
+        CancellationToken cancellationToken = default);
 }
 
 public abstract partial class SHA3_512 : HashAlgorithm {
@@ -61,89 +179,390 @@ public abstract partial class SHA3_512 : HashAlgorithm {
 
     protected SHA3_512();
 
+    [UnsupportedOSPlatformGuard("ios")]
+    [UnsupportedOSPlatformGuard("tvos")]
+    [UnsupportedOSPlatformGuard("android")]
+    [UnsupportedOSPlatformGuard("browser")]
+    [UnsupportedOSPlatformGuard("osx")]
     public static bool IsSupported { get; }
 
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("android")]
+    [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("osx")]
     public static new SHA3_512 Create();
 
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("android")]
+    [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("osx")]
     public static byte[] HashData(byte[] source);
+
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("android")]
+    [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("osx")]
     public static byte[] HashData(ReadOnlySpan<byte> source);
+
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("android")]
+    [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("osx")]
     public static int HashData(ReadOnlySpan<byte> source, Span<byte> destination);
+
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("android")]
+    [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("osx")]
     public static bool TryHashData(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesWritten);
 
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("android")]
+    [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("osx")]
     public static byte[] HashData(Stream source);
-    public static int HashData(Stream source, Span<byte> destination);
-    public static ValueTask<int> HashDataAsync(Stream source, Memory<byte> destination, CancellationToken cancellationToken = default);
-    public static ValueTask<byte[]> HashDataAsync(Stream source, CancellationToken cancellationToken = default);
-}
 
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("android")]
+    [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("osx")]
+    public static int HashData(Stream source, Span<byte> destination);
+
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("android")]
+    [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("osx")]
+    public static ValueTask<byte[]> HashDataAsync(Stream source, CancellationToken cancellationToken = default);
+
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("android")]
+    [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("osx")]
+    public static ValueTask<int> HashDataAsync(
+        Stream source,
+        Memory<byte> destination,
+        CancellationToken cancellationToken = default);
+}
 
 public partial class HMACSHA3_256 : HMAC {
     public const int HashSizeInBits = 256;
     public const int HashSizeInBytes = 32;
 
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("android")]
+    [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("osx")]
     public HMACSHA3_256();
+
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("android")]
+    [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("osx")]
     public HMACSHA3_256(byte[] key);
 
+    [UnsupportedOSPlatformGuard("ios")]
+    [UnsupportedOSPlatformGuard("tvos")]
+    [UnsupportedOSPlatformGuard("android")]
+    [UnsupportedOSPlatformGuard("browser")]
+    [UnsupportedOSPlatformGuard("osx")]
     public static bool IsSupported { get; } // New
 
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("android")]
+    [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("osx")]
     public static byte[] HashData(byte[] key, byte[] source);
-    public static byte[] HashData(ReadOnlySpan<byte> key, ReadOnlySpan<byte> source);
-    public static int HashData(ReadOnlySpan<byte> key, ReadOnlySpan<byte> source, Span<byte> destination);
-    public static bool TryHashData(ReadOnlySpan<byte> key, ReadOnlySpan<byte> source, Span<byte> destination, out int bytesWritten);
 
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("android")]
+    [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("osx")]
+    public static byte[] HashData(ReadOnlySpan<byte> key, ReadOnlySpan<byte> source);
+
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("android")]
+    [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("osx")]
+    public static int HashData(ReadOnlySpan<byte> key, ReadOnlySpan<byte> source, Span<byte> destination);
+
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("android")]
+    [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("osx")]
+    public static bool TryHashData(
+        ReadOnlySpan<byte> key,
+        ReadOnlySpan<byte> source,
+        Span<byte> destination,
+        out int bytesWritten);
+
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("android")]
+    [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("osx")]
     public static byte[] HashData(byte[] key, Stream source);
+
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("android")]
+    [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("osx")]
     public static byte[] HashData(ReadOnlySpan<byte> key, Stream source);
+
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("android")]
+    [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("osx")]
     public static int HashData(ReadOnlySpan<byte> key, Stream source, Span<byte> destination);
 
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("android")]
+    [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("osx")]
     public static ValueTask<byte[]> HashDataAsync(byte[] key, Stream source, CancellationToken cancellationToken = default);
-    public static ValueTask<int> HashDataAsync(ReadOnlyMemory<byte> key, Stream source, Memory<byte> destination, CancellationToken cancellationToken = default);
+
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("android")]
+    [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("osx")]
     public static ValueTask<byte[]> HashDataAsync(ReadOnlyMemory<byte> key, Stream source, CancellationToken cancellationToken = default);
+
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("android")]
+    [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("osx")]
+    public static ValueTask<int> HashDataAsync(
+        ReadOnlyMemory<byte> key,
+        Stream source,
+        Memory<byte> destination,
+        CancellationToken cancellationToken = default);
 }
 
 public partial class HMACSHA3_384 : HMAC {
     public const int HashSizeInBits = 384;
     public const int HashSizeInBytes = 48;
 
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("android")]
+    [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("osx")]
     public HMACSHA3_384();
+
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("android")]
+    [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("osx")]
     public HMACSHA3_384(byte[] key);
 
+    [UnsupportedOSPlatformGuard("ios")]
+    [UnsupportedOSPlatformGuard("tvos")]
+    [UnsupportedOSPlatformGuard("android")]
+    [UnsupportedOSPlatformGuard("browser")]
+    [UnsupportedOSPlatformGuard("osx")]
     public static bool IsSupported { get; } // New
 
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("android")]
+    [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("osx")]
     public static byte[] HashData(byte[] key, byte[] source);
-    public static byte[] HashData(ReadOnlySpan<byte> key, ReadOnlySpan<byte> source);
-    public static int HashData(ReadOnlySpan<byte> key, ReadOnlySpan<byte> source, Span<byte> destination);
-    public static bool TryHashData(ReadOnlySpan<byte> key, ReadOnlySpan<byte> source, Span<byte> destination, out int bytesWritten);
 
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("android")]
+    [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("osx")]
+    public static byte[] HashData(ReadOnlySpan<byte> key, ReadOnlySpan<byte> source);
+
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("android")]
+    [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("osx")]
+    public static int HashData(ReadOnlySpan<byte> key, ReadOnlySpan<byte> source, Span<byte> destination);
+
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("android")]
+    [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("osx")]
+    public static bool TryHashData(
+        ReadOnlySpan<byte> key,
+        ReadOnlySpan<byte> source,
+        Span<byte> destination,
+        out int bytesWritten);
+
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("android")]
+    [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("osx")]
     public static byte[] HashData(byte[] key, Stream source);
+
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("android")]
+    [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("osx")]
     public static byte[] HashData(ReadOnlySpan<byte> key, Stream source);
+
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("android")]
+    [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("osx")]
     public static int HashData(ReadOnlySpan<byte> key, Stream source, Span<byte> destination);
 
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("android")]
+    [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("osx")]
     public static ValueTask<byte[]> HashDataAsync(byte[] key, Stream source, CancellationToken cancellationToken = default);
-    public static ValueTask<int> HashDataAsync(ReadOnlyMemory<byte> key, Stream source, Memory<byte> destination, CancellationToken cancellationToken = default);
+
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("android")]
+    [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("osx")]
     public static ValueTask<byte[]> HashDataAsync(ReadOnlyMemory<byte> key, Stream source, CancellationToken cancellationToken = default);
+
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("android")]
+    [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("osx")]
+    public static ValueTask<int> HashDataAsync(
+        ReadOnlyMemory<byte> key,
+        Stream source,
+        Memory<byte> destination,
+        CancellationToken cancellationToken = default);
 }
 
 public partial class HMACSHA3_512 : HMAC {
     public const int HashSizeInBits = 512;
     public const int HashSizeInBytes = 64;
 
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("android")]
+    [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("osx")]
     public HMACSHA3_512();
+
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("android")]
+    [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("osx")]
     public HMACSHA3_512(byte[] key);
 
+    [UnsupportedOSPlatformGuard("ios")]
+    [UnsupportedOSPlatformGuard("tvos")]
+    [UnsupportedOSPlatformGuard("android")]
+    [UnsupportedOSPlatformGuard("browser")]
+    [UnsupportedOSPlatformGuard("osx")]
     public static bool IsSupported { get; } // New
 
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("android")]
+    [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("osx")]
     public static byte[] HashData(byte[] key, byte[] source);
-    public static byte[] HashData(ReadOnlySpan<byte> key, ReadOnlySpan<byte> source);
-    public static int HashData(ReadOnlySpan<byte> key, ReadOnlySpan<byte> source, Span<byte> destination);
-    public static bool TryHashData(ReadOnlySpan<byte> key, ReadOnlySpan<byte> source, Span<byte> destination, out int bytesWritten);
 
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("android")]
+    [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("osx")]
+    public static byte[] HashData(ReadOnlySpan<byte> key, ReadOnlySpan<byte> source);
+
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("android")]
+    [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("osx")]
+    public static int HashData(ReadOnlySpan<byte> key, ReadOnlySpan<byte> source, Span<byte> destination);
+
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("android")]
+    [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("osx")]
+    public static bool TryHashData(
+        ReadOnlySpan<byte> key,
+        ReadOnlySpan<byte> source,
+        Span<byte> destination,
+        out int bytesWritten);
+
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("android")]
+    [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("osx")]
     public static byte[] HashData(byte[] key, Stream source);
+
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("android")]
+    [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("osx")]
     public static byte[] HashData(ReadOnlySpan<byte> key, Stream source);
+
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("android")]
+    [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("osx")]
     public static int HashData(ReadOnlySpan<byte> key, Stream source, Span<byte> destination);
 
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("android")]
+    [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("osx")]
     public static ValueTask<byte[]> HashDataAsync(byte[] key, Stream source, CancellationToken cancellationToken = default);
-    public static ValueTask<int> HashDataAsync(ReadOnlyMemory<byte> key, Stream source, Memory<byte> destination, CancellationToken cancellationToken = default);
+
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("android")]
+    [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("osx")]
     public static ValueTask<byte[]> HashDataAsync(ReadOnlyMemory<byte> key, Stream source, CancellationToken cancellationToken = default);
+
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("android")]
+    [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("osx")]
+    public static ValueTask<int> HashDataAsync(
+        ReadOnlyMemory<byte> key,
+        Stream source,
+        Memory<byte> destination,
+        CancellationToken cancellationToken = default);
 }
 
 public abstract partial class Shake : IDisposable {
@@ -151,41 +570,148 @@ public abstract partial class Shake : IDisposable {
 
     public void AppendData(byte[] data);
     public void AppendData(ReadOnlySpan<byte> data);
+    protected abstract void AppendDataCore(ReadOnlySpan<byte> data);
 
     public byte[] GetCurrentHash(int outputLength);
     public void GetCurrentHash(Span<byte> destination);
+    protected abstract void GetCurrentHashCore(Span<byte> destination);
+
     public byte[] GetHashAndReset(int outputLength);
     public void GetHashAndReset(Span<byte> destination);
+    protected abstract void GetHashAndResetCore(Span<byte> destination);
 
     public void Dispose();
+    protected virtual void Dispose(bool disposing);
 }
 
 public sealed partial class Shake128 : Shake {
+
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("android")]
+    [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("osx")]
     public Shake128();
 
+    [UnsupportedOSPlatformGuard("ios")]
+    [UnsupportedOSPlatformGuard("tvos")]
+    [UnsupportedOSPlatformGuard("android")]
+    [UnsupportedOSPlatformGuard("browser")]
+    [UnsupportedOSPlatformGuard("osx")]
     public static bool IsSupported { get; }
 
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("android")]
+    [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("osx")]
     public static byte[] HashData(byte[] source, int outputLength);
+
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("android")]
+    [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("osx")]
     public static byte[] HashData(ReadOnlySpan<byte> source, int outputLength);
+
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("android")]
+    [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("osx")]
     public static void HashData(ReadOnlySpan<byte> source, Span<byte> destination);
 
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("android")]
+    [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("osx")]
     public static byte[] HashData(Stream source, int outputLength);
+
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("android")]
+    [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("osx")]
     public static void HashData(Stream source, Span<byte> destination);
+
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("android")]
+    [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("osx")]
     public static ValueTask HashDataAsync(Stream source, Memory<byte> destination, CancellationToken cancellationToken = default);
+
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("android")]
+    [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("osx")]
     public static ValueTask<byte[]> HashDataAsync(Stream source, int outputLength, CancellationToken cancellationToken = default);
 }
 
 public sealed partial class Shake256 : Shake {
+
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("android")]
+    [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("osx")]
     public Shake256();
 
+    [UnsupportedOSPlatformGuard("ios")]
+    [UnsupportedOSPlatformGuard("tvos")]
+    [UnsupportedOSPlatformGuard("android")]
+    [UnsupportedOSPlatformGuard("browser")]
+    [UnsupportedOSPlatformGuard("osx")]
     public static bool IsSupported { get; }
 
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("android")]
+    [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("osx")]
     public static byte[] HashData(byte[] source, int outputLength);
+
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("android")]
+    [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("osx")]
     public static byte[] HashData(ReadOnlySpan<byte> source, int outputLength);
+
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("android")]
+    [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("osx")]
     public static void HashData(ReadOnlySpan<byte> source, Span<byte> destination);
 
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("android")]
+    [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("osx")]
     public static byte[] HashData(Stream source, int outputLength);
+
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("android")]
+    [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("osx")]
     public static void HashData(Stream source, Span<byte> destination);
+
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("android")]
+    [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("osx")]
     public static ValueTask HashDataAsync(Stream source, Memory<byte> destination, CancellationToken cancellationToken = default);
+
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("android")]
+    [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("osx")]
     public static ValueTask<byte[]> HashDataAsync(Stream source, int outputLength, CancellationToken cancellationToken = default);
 }


### PR DESCRIPTION
Brain dumping things

1. `SHA3_{256, 384, 512}` are straight forward copies of the existing SHA-2 primitives. There is one addition of an `IsSupported` attribute, and it's annotated with `UnsupportedOSPlatform`.
2. Ditto the above, but for HMAC.
3. This proposal does not include KMAC. I propose punting on this for .NET 9+. It's non-trivial to introduce. Since it's an OpenSSL 3+ API, we would have many new native shims to write, and our CI protection of OpenSSL 3 is incomplete so I would have a hard time having confidence in the implementation.