### PR TITLE
Generalized Vectorization

### DIFF
--- a/src/libraries/System.IO.Hashing/src/System.IO.Hashing.csproj
+++ b/src/libraries/System.IO.Hashing/src/System.IO.Hashing.csproj
@@ -37,7 +37,10 @@ System.IO.Hashing.XxHash32</PackageDescription>
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
     <Compile Include="System\IO\Hashing\Crc32.Arm.cs" />
     <Compile Include="System\IO\Hashing\Crc32.Vectorized.cs" />
+    <Compile Include="System\IO\Hashing\Crc32ParameterSet.Vectorized.cs" />
     <Compile Include="System\IO\Hashing\Crc64.Vectorized.cs" />
+    <Compile Include="System\IO\Hashing\Crc64ParameterSet.Vectorized.cs" />
+    <Compile Include="System\IO\Hashing\CrcPolynomialHelper.cs" />
     <Compile Include="System\IO\Hashing\VectorHelper.cs" />
     <Compile Include="System\ThrowHelper.cs" />
   </ItemGroup>

--- a/src/libraries/System.IO.Hashing/src/System/IO/Hashing/Crc32ParameterSet.Vectorized.cs
+++ b/src/libraries/System.IO.Hashing/src/System/IO/Hashing/Crc32ParameterSet.Vectorized.cs
@@ -1,0 +1,159 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#if NET
+
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
+using static System.IO.Hashing.VectorHelper;
+
+namespace System.IO.Hashing
+{
+    public partial class Crc32ParameterSet
+    {
+        private sealed partial class ReflectedTableBasedCrc32
+        {
+            // For reflected CRC-32, the folding constants are computed as:
+            //   constant = bit_reverse(x^power mod P(x), 33)
+            // where P(x) is the NORMAL (unreflected) polynomial with explicit leading x^32 bit.
+            // The Barrett reduction vector stores [reflect(P, 33), reflect(mu, 33)]
+            // where mu = floor(x^64 / P(x)).
+            private Vector128<ulong> _k1k2;
+            private Vector128<ulong> _k3k4;
+            private ulong _k5;
+            private ulong _k6;
+            private Vector128<ulong> _barrettConstants;
+            private bool _canVectorize;
+
+            partial void InitializeVectorizedConstants()
+            {
+                if (!BitConverter.IsLittleEndian || !VectorHelper.IsSupported)
+                {
+                    return;
+                }
+
+                UInt128 fullPoly = (UInt128)1 << 32 | Polynomial;
+
+                _k1k2 = Vector128.Create(
+                    ReflectConstant(CrcPolynomialHelper.ComputeFoldingConstant(fullPoly, 32, 4 * 128 + 32), 33),
+                    ReflectConstant(CrcPolynomialHelper.ComputeFoldingConstant(fullPoly, 32, 4 * 128 - 32), 33));
+
+                ulong k3 = ReflectConstant(CrcPolynomialHelper.ComputeFoldingConstant(fullPoly, 32, 128 + 32), 33);
+                ulong k4 = ReflectConstant(CrcPolynomialHelper.ComputeFoldingConstant(fullPoly, 32, 128 - 32), 33);
+                _k3k4 = Vector128.Create(k3, k4);
+
+                _k5 = k4;
+                _k6 = ReflectConstant(CrcPolynomialHelper.ComputeFoldingConstant(fullPoly, 32, 64), 33);
+
+                ulong mu = CrcPolynomialHelper.ComputeBarrettConstant(fullPoly, 32);
+                _barrettConstants = Vector128.Create(
+                    ReflectConstant((ulong)fullPoly, 33),
+                    ReflectConstant(mu, 33));
+
+                _canVectorize = true;
+            }
+
+            partial void UpdateVectorized(ref uint crc, ReadOnlySpan<byte> source, ref int bytesConsumed)
+            {
+                if (!_canVectorize || source.Length < Vector128<byte>.Count)
+                {
+                    return;
+                }
+
+                crc = UpdateVectorizedCore(crc, source, out bytesConsumed);
+            }
+
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            private uint UpdateVectorizedCore(uint crc, ReadOnlySpan<byte> source, out int bytesConsumed)
+            {
+                ref byte srcRef = ref MemoryMarshal.GetReference(source);
+                int length = source.Length;
+
+                Vector128<ulong> x1;
+                Vector128<ulong> x2;
+
+                if (length >= Vector128<byte>.Count * 4)
+                {
+                    x1 = Vector128.LoadUnsafe(ref srcRef).AsUInt64();
+                    x2 = Vector128.LoadUnsafe(ref srcRef, 16).AsUInt64();
+                    Vector128<ulong> x3 = Vector128.LoadUnsafe(ref srcRef, 32).AsUInt64();
+                    Vector128<ulong> x4 = Vector128.LoadUnsafe(ref srcRef, 48).AsUInt64();
+
+                    srcRef = ref Unsafe.Add(ref srcRef, Vector128<byte>.Count * 4);
+                    length -= Vector128<byte>.Count * 4;
+
+                    x1 ^= Vector128.CreateScalar(crc).AsUInt64();
+
+                    while (length >= Vector128<byte>.Count * 4)
+                    {
+                        Vector128<ulong> y5 = Vector128.LoadUnsafe(ref srcRef).AsUInt64();
+                        Vector128<ulong> y6 = Vector128.LoadUnsafe(ref srcRef, 16).AsUInt64();
+                        Vector128<ulong> y7 = Vector128.LoadUnsafe(ref srcRef, 32).AsUInt64();
+                        Vector128<ulong> y8 = Vector128.LoadUnsafe(ref srcRef, 48).AsUInt64();
+
+                        x1 = FoldPolynomialPair(y5, x1, _k1k2);
+                        x2 = FoldPolynomialPair(y6, x2, _k1k2);
+                        x3 = FoldPolynomialPair(y7, x3, _k1k2);
+                        x4 = FoldPolynomialPair(y8, x4, _k1k2);
+
+                        srcRef = ref Unsafe.Add(ref srcRef, Vector128<byte>.Count * 4);
+                        length -= Vector128<byte>.Count * 4;
+                    }
+
+                    x1 = FoldPolynomialPair(x2, x1, _k3k4);
+                    x1 = FoldPolynomialPair(x3, x1, _k3k4);
+                    x1 = FoldPolynomialPair(x4, x1, _k3k4);
+                }
+                else
+                {
+                    x1 = Vector128.LoadUnsafe(ref srcRef).AsUInt64();
+                    x1 ^= Vector128.CreateScalar(crc).AsUInt64();
+
+                    srcRef = ref Unsafe.Add(ref srcRef, Vector128<byte>.Count);
+                    length -= Vector128<byte>.Count;
+                }
+
+                while (length >= Vector128<byte>.Count)
+                {
+                    x1 = FoldPolynomialPair(Vector128.LoadUnsafe(ref srcRef).AsUInt64(), x1, _k3k4);
+
+                    srcRef = ref Unsafe.Add(ref srcRef, Vector128<byte>.Count);
+                    length -= Vector128<byte>.Count;
+                }
+
+                // Fold 128 bits to 64 bits.
+                Vector128<ulong> bitmask = Vector128.Create(~0, 0, ~0, 0).AsUInt64();
+                x1 = ShiftRightBytesInVector(x1, 8) ^
+                     CarrylessMultiplyLower(x1, Vector128.CreateScalar(_k5));
+                x1 = CarrylessMultiplyLower(x1 & bitmask, Vector128.CreateScalar(_k6)) ^
+                     ShiftRightBytesInVector(x1, 4);
+
+                // Barrett reduction to 32 bits.
+                x2 = CarrylessMultiplyLeftLowerRightUpper(x1 & bitmask, _barrettConstants) & bitmask;
+                x2 = CarrylessMultiplyLower(x2, _barrettConstants);
+                x1 ^= x2;
+
+                bytesConsumed = source.Length - length;
+
+                return x1.AsUInt32().GetElement(1);
+            }
+        }
+
+        private static ulong ReflectConstant(ulong value, int width)
+        {
+            ulong result = 0;
+            for (int i = 0; i < width; i++)
+            {
+                if (((value >> i) & 1) != 0)
+                {
+                    result |= 1UL << (width - 1 - i);
+                }
+            }
+
+            return result;
+        }
+    }
+}
+
+#endif

--- a/src/libraries/System.IO.Hashing/src/System/IO/Hashing/Crc32ParameterSet.Vectorized.cs
+++ b/src/libraries/System.IO.Hashing/src/System/IO/Hashing/Crc32ParameterSet.Vectorized.cs
@@ -140,6 +140,160 @@ namespace System.IO.Hashing
             }
         }
 
+        private sealed partial class ForwardTableBasedCrc32
+        {
+            // For forward CRC-32, the folding constants are computed directly:
+            //   constant = x^power mod P(x)
+            // Data is loaded with byte-reversal (MSB first), CRC placed in upper bits.
+            // The 128→64 reduction uses FoldPolynomialPair with [x^32, x^96] to embed
+            // the required x^32 shift factor, then one more fold with x^64, then Barrett.
+            private Vector128<ulong> _k1k2;
+            private Vector128<ulong> _k3k4;
+            private Vector128<ulong> _foldConstants;
+            private ulong _k5;
+            private ulong _mu;
+            private ulong _polyFull;
+            private bool _canVectorize;
+
+            partial void InitializeVectorizedConstants()
+            {
+                if (!BitConverter.IsLittleEndian || !VectorHelper.IsSupported)
+                {
+                    return;
+                }
+
+                UInt128 fullPoly = (UInt128)1 << 32 | Polynomial;
+
+                _k1k2 = Vector128.Create(
+                    CrcPolynomialHelper.ComputeFoldingConstant(fullPoly, 32, 4 * 128),
+                    CrcPolynomialHelper.ComputeFoldingConstant(fullPoly, 32, 4 * 128 + 64));
+
+                ulong k3 = CrcPolynomialHelper.ComputeFoldingConstant(fullPoly, 32, 128);
+                ulong k4 = CrcPolynomialHelper.ComputeFoldingConstant(fullPoly, 32, 128 + 64);
+                _k3k4 = Vector128.Create(k3, k4);
+
+                // Constants for 128→~96 fold: [x^32 mod P, x^96 mod P]
+                // This computes L*x^32 + H*x^96 = x^32*(H*x^64 + L) = x^32*V (mod P),
+                // which embeds the CRC's required x^32 shift factor.
+                _foldConstants = Vector128.Create(
+                    CrcPolynomialHelper.ComputeFoldingConstant(fullPoly, 32, 32),
+                    CrcPolynomialHelper.ComputeFoldingConstant(fullPoly, 32, 96));
+
+                _k5 = CrcPolynomialHelper.ComputeFoldingConstant(fullPoly, 32, 64);
+                _mu = CrcPolynomialHelper.ComputeBarrettConstant(fullPoly, 32);
+                _polyFull = (ulong)fullPoly;
+
+                _canVectorize = true;
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            private static Vector128<ulong> LoadReversed(ref byte source, nuint elementOffset)
+            {
+                Vector128<byte> vector = Vector128.LoadUnsafe(ref source, elementOffset);
+
+                if (BitConverter.IsLittleEndian)
+                {
+                    vector = Vector128.Shuffle(vector,
+                        Vector128.Create((byte)0x0F, 0x0E, 0x0D, 0x0C, 0x0B, 0x0A, 0x09, 0x08,
+                                               0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01, 0x00));
+                }
+
+                return vector.AsUInt64();
+            }
+
+            partial void UpdateVectorized(ref uint crc, ReadOnlySpan<byte> source, ref int bytesConsumed)
+            {
+                if (!_canVectorize || source.Length < Vector128<byte>.Count)
+                {
+                    return;
+                }
+
+                crc = UpdateVectorizedCore(crc, source, out bytesConsumed);
+            }
+
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            private uint UpdateVectorizedCore(uint crc, ReadOnlySpan<byte> source, out int bytesConsumed)
+            {
+                ref byte srcRef = ref MemoryMarshal.GetReference(source);
+                int length = source.Length;
+
+                Vector128<ulong> x1;
+
+                if (length >= Vector128<byte>.Count * 4)
+                {
+                    x1 = LoadReversed(ref srcRef, 0);
+                    Vector128<ulong> x2 = LoadReversed(ref srcRef, 16);
+                    Vector128<ulong> x3 = LoadReversed(ref srcRef, 32);
+                    Vector128<ulong> x4 = LoadReversed(ref srcRef, 48);
+
+                    srcRef = ref Unsafe.Add(ref srcRef, Vector128<byte>.Count * 4);
+                    length -= Vector128<byte>.Count * 4;
+
+                    x1 ^= ShiftLowerToUpper(Vector128.CreateScalar((ulong)crc << 32));
+
+                    while (length >= Vector128<byte>.Count * 4)
+                    {
+                        Vector128<ulong> y5 = LoadReversed(ref srcRef, 0);
+                        Vector128<ulong> y6 = LoadReversed(ref srcRef, 16);
+                        Vector128<ulong> y7 = LoadReversed(ref srcRef, 32);
+                        Vector128<ulong> y8 = LoadReversed(ref srcRef, 48);
+
+                        x1 = FoldPolynomialPair(y5, x1, _k1k2);
+                        x2 = FoldPolynomialPair(y6, x2, _k1k2);
+                        x3 = FoldPolynomialPair(y7, x3, _k1k2);
+                        x4 = FoldPolynomialPair(y8, x4, _k1k2);
+
+                        srcRef = ref Unsafe.Add(ref srcRef, Vector128<byte>.Count * 4);
+                        length -= Vector128<byte>.Count * 4;
+                    }
+
+                    x1 = FoldPolynomialPair(x2, x1, _k3k4);
+                    x1 = FoldPolynomialPair(x3, x1, _k3k4);
+                    x1 = FoldPolynomialPair(x4, x1, _k3k4);
+                }
+                else
+                {
+                    x1 = LoadReversed(ref srcRef, 0);
+                    x1 ^= ShiftLowerToUpper(Vector128.CreateScalar((ulong)crc << 32));
+
+                    srcRef = ref Unsafe.Add(ref srcRef, Vector128<byte>.Count);
+                    length -= Vector128<byte>.Count;
+                }
+
+                while (length >= Vector128<byte>.Count)
+                {
+                    x1 = FoldPolynomialPair(LoadReversed(ref srcRef, 0), x1, _k3k4);
+
+                    srcRef = ref Unsafe.Add(ref srcRef, Vector128<byte>.Count);
+                    length -= Vector128<byte>.Count;
+                }
+
+                // Fold 128→~96 bits using FoldPolynomialPair with [x^32 mod P, x^96 mod P].
+                // This computes x^32*V (mod P), embedding the x^32 shift factor
+                // that forward CRC requires (CRC = M(x)*x^32 mod P).
+                x1 = FoldPolynomialPair(Vector128<ulong>.Zero, x1, _foldConstants);
+
+                // Fold ~96→64 bits: the result has at most ~95 bits (32-bit constants × 64-bit data).
+                // Fold the upper bits down using x^64 mod P.
+                Vector128<ulong> lowerMask = Vector128.Create(~0UL, 0UL);
+                x1 = CarrylessMultiplyLeftUpperRightLower(x1, Vector128.CreateScalar(_k5)) ^ (x1 & lowerMask);
+
+                // Barrett reduction: 64→32 bits.
+                // t = V >> 32, q = (t * μ) >> 32, r = V ^ (q * P)
+                Vector128<ulong> bitmask = Vector128.Create(~0, 0, ~0, 0).AsUInt64();
+                Vector128<ulong> temp = x1;
+                x1 = ShiftRightBytesInVector(x1, 4) & bitmask;
+                x1 = CarrylessMultiplyLower(x1, Vector128.CreateScalar(_mu));
+                x1 = ShiftRightBytesInVector(x1, 4) & bitmask;
+                x1 = CarrylessMultiplyLower(x1, Vector128.CreateScalar(_polyFull));
+                x1 ^= temp;
+
+                bytesConsumed = source.Length - length;
+
+                return x1.AsUInt32().GetElement(0);
+            }
+        }
+
         private static ulong ReflectConstant(ulong value, int width)
         {
             ulong result = 0;

--- a/src/libraries/System.IO.Hashing/src/System/IO/Hashing/Crc64ParameterSet.Vectorized.cs
+++ b/src/libraries/System.IO.Hashing/src/System/IO/Hashing/Crc64ParameterSet.Vectorized.cs
@@ -1,0 +1,153 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#if NET
+
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
+using static System.IO.Hashing.VectorHelper;
+
+namespace System.IO.Hashing
+{
+    public partial class Crc64ParameterSet
+    {
+        private sealed partial class ForwardTableBasedCrc64
+        {
+            // For forward CRC-64, constants are computed directly:
+            //   constant = x^power mod P(x)
+            // Data is byte-reversed on load. CRC placed in upper bits.
+            private Vector128<ulong> _k1k2;
+            private Vector128<ulong> _k3k4;
+            private ulong _k5;
+            private Vector128<ulong> _barrettConstants;
+            private bool _canVectorize;
+
+            partial void InitializeVectorizedConstants()
+            {
+                if (!BitConverter.IsLittleEndian || !VectorHelper.IsSupported)
+                {
+                    return;
+                }
+
+                UInt128 fullPoly = (UInt128)1 << 64 | Polynomial;
+
+                _k1k2 = Vector128.Create(
+                    CrcPolynomialHelper.ComputeFoldingConstant(fullPoly, 64, 4 * 128),
+                    CrcPolynomialHelper.ComputeFoldingConstant(fullPoly, 64, 4 * 128 + 64));
+
+                ulong k3 = CrcPolynomialHelper.ComputeFoldingConstant(fullPoly, 64, 128);
+                ulong k4 = CrcPolynomialHelper.ComputeFoldingConstant(fullPoly, 64, 128 + 64);
+                _k3k4 = Vector128.Create(k3, k4);
+
+                _k5 = k3;
+
+                ulong mu = CrcPolynomialHelper.ComputeBarrettConstant(fullPoly, 64);
+                _barrettConstants = Vector128.Create(mu, (ulong)fullPoly);
+
+                _canVectorize = true;
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            private static Vector128<ulong> LoadReversed(ref byte source, nuint elementOffset)
+            {
+                Vector128<byte> vector = Vector128.LoadUnsafe(ref source, elementOffset);
+
+                if (BitConverter.IsLittleEndian)
+                {
+                    vector = Vector128.Shuffle(vector,
+                        Vector128.Create((byte)0x0F, 0x0E, 0x0D, 0x0C, 0x0B, 0x0A, 0x09, 0x08,
+                                               0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01, 0x00));
+                }
+
+                return vector.AsUInt64();
+            }
+
+            partial void UpdateVectorized(ref ulong crc, ReadOnlySpan<byte> source, ref int bytesConsumed)
+            {
+                if (!_canVectorize || source.Length < Vector128<byte>.Count)
+                {
+                    return;
+                }
+
+                crc = UpdateVectorizedCore(crc, source, out bytesConsumed);
+            }
+
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            private ulong UpdateVectorizedCore(ulong crc, ReadOnlySpan<byte> source, out int bytesConsumed)
+            {
+                ref byte srcRef = ref MemoryMarshal.GetReference(source);
+                int length = source.Length;
+
+                Vector128<ulong> x1;
+
+                if (length >= Vector128<byte>.Count * 4)
+                {
+                    x1 = LoadReversed(ref srcRef, 0);
+                    Vector128<ulong> x2 = LoadReversed(ref srcRef, 16);
+                    Vector128<ulong> x3 = LoadReversed(ref srcRef, 32);
+                    Vector128<ulong> x4 = LoadReversed(ref srcRef, 48);
+
+                    srcRef = ref Unsafe.Add(ref srcRef, Vector128<byte>.Count * 4);
+                    length -= Vector128<byte>.Count * 4;
+
+                    x1 ^= ShiftLowerToUpper(Vector128.CreateScalar(crc));
+
+                    while (length >= Vector128<byte>.Count * 4)
+                    {
+                        Vector128<ulong> y5 = LoadReversed(ref srcRef, 0);
+                        Vector128<ulong> y6 = LoadReversed(ref srcRef, 16);
+                        Vector128<ulong> y7 = LoadReversed(ref srcRef, 32);
+                        Vector128<ulong> y8 = LoadReversed(ref srcRef, 48);
+
+                        x1 = FoldPolynomialPair(y5, x1, _k1k2);
+                        x2 = FoldPolynomialPair(y6, x2, _k1k2);
+                        x3 = FoldPolynomialPair(y7, x3, _k1k2);
+                        x4 = FoldPolynomialPair(y8, x4, _k1k2);
+
+                        srcRef = ref Unsafe.Add(ref srcRef, Vector128<byte>.Count * 4);
+                        length -= Vector128<byte>.Count * 4;
+                    }
+
+                    x1 = FoldPolynomialPair(x2, x1, _k3k4);
+                    x1 = FoldPolynomialPair(x3, x1, _k3k4);
+                    x1 = FoldPolynomialPair(x4, x1, _k3k4);
+                }
+                else
+                {
+                    x1 = LoadReversed(ref srcRef, 0);
+                    x1 ^= ShiftLowerToUpper(Vector128.CreateScalar(crc));
+
+                    srcRef = ref Unsafe.Add(ref srcRef, Vector128<byte>.Count);
+                    length -= Vector128<byte>.Count;
+                }
+
+                while (length >= Vector128<byte>.Count)
+                {
+                    x1 = FoldPolynomialPair(LoadReversed(ref srcRef, 0), x1, _k3k4);
+
+                    srcRef = ref Unsafe.Add(ref srcRef, Vector128<byte>.Count);
+                    length -= Vector128<byte>.Count;
+                }
+
+                // Fold 128→64 bits (forward: fold upper into lower)
+                x1 = CarrylessMultiplyLeftUpperRightLower(x1, Vector128.CreateScalar(_k5)) ^
+                     ShiftLowerToUpper(x1);
+
+                // Barrett reduction
+                Vector128<ulong> temp = x1;
+                x1 = CarrylessMultiplyLeftUpperRightLower(x1, _barrettConstants) ^
+                     (x1 & Vector128.Create(0UL, ~0UL));
+                x1 = CarrylessMultiplyUpper(x1, _barrettConstants);
+                x1 ^= temp;
+
+                bytesConsumed = source.Length - length;
+
+                return x1.GetElement(0);
+            }
+        }
+
+    }
+}
+
+#endif

--- a/src/libraries/System.IO.Hashing/src/System/IO/Hashing/CrcPolynomialHelper.cs
+++ b/src/libraries/System.IO.Hashing/src/System/IO/Hashing/CrcPolynomialHelper.cs
@@ -1,0 +1,189 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#if NET
+
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace System.IO.Hashing
+{
+    /// <summary>
+    /// Provides helper methods for computing CRC polynomial folding constants
+    /// used in SIMD-accelerated CRC computation.
+    /// </summary>
+    /// <remarks>
+    /// The folding constants are values of x^n mod P(x) in GF(2) for various powers n.
+    /// These are used in the Intel PCLMULQDQ-based CRC algorithm described in
+    /// "Fast CRC Computation for Generic Polynomials Using PCLMULQDQ Instruction" (December 2009).
+    /// </remarks>
+    internal static class CrcPolynomialHelper
+    {
+        /// <summary>
+        /// Computes x^<paramref name="power"/> mod P(x) in GF(2), where P(x) is a polynomial
+        /// of degree <paramref name="polyDeg"/> represented by <paramref name="poly"/>.
+        /// </summary>
+        /// <param name="poly">
+        /// The polynomial with the explicit leading bit set.
+        /// For CRC-32 with polynomial 0x04C11DB7, pass 0x104C11DB7.
+        /// For CRC-64 with polynomial 0x42F0E1EBA9EA3693, pass 0x142F0E1EBA9EA3693 (as UInt128).
+        /// </param>
+        /// <param name="polyDeg">The degree of the polynomial (32 for CRC-32, 64 for CRC-64).</param>
+        /// <param name="power">The power of x to compute (e.g. 4*128+64 for k1).</param>
+        /// <returns>The result of x^power mod P(x), fitting in a ulong.</returns>
+        internal static ulong ComputeFoldingConstant(UInt128 poly, int polyDeg, int power)
+        {
+            Debug.Assert(polyDeg is 32 or 64);
+            Debug.Assert(power > 0);
+
+            // We need enough bits to hold x^power before reducing.
+            // x^power has one bit at position 'power', so we need power+1 bits.
+            // Maximum power for 4-way CRC-32 fold: 4*128+64 = 576, so 577 bits = 10 ulongs.
+            // Maximum power for 4-way CRC-64 fold: 4*128+64 = 576, so 577+32 bits = 10 ulongs.
+            UInt640 value = default;
+            value.SetBit(power);
+
+            // Reduce: while degree(value) >= polyDeg, XOR with poly shifted appropriately
+            int valueDegree = value.Degree;
+
+            while (valueDegree >= polyDeg)
+            {
+                int shift = valueDegree - polyDeg;
+                UInt640 polyShifted = default;
+                polyShifted.SetFromUInt128(poly);
+                polyShifted.ShiftLeft(shift);
+                value.Xor(ref polyShifted);
+                valueDegree = value.Degree;
+            }
+
+            return value.ToUInt64();
+        }
+
+        /// <summary>
+        /// Computes the Barrett reduction constant μ = ⌊x^(2*polyDeg) / P(x)⌋ in GF(2).
+        /// </summary>
+        /// <param name="poly">The polynomial with the explicit leading bit set.</param>
+        /// <param name="polyDeg">The degree of the polynomial (32 or 64).</param>
+        /// <returns>The Barrett constant μ.</returns>
+        internal static ulong ComputeBarrettConstant(UInt128 poly, int polyDeg)
+        {
+            Debug.Assert(polyDeg is 32 or 64);
+
+            // We compute x^(2*polyDeg) / P(x) = quotient in GF(2) polynomial division.
+            // x^(2*polyDeg) has bit at position 2*polyDeg.
+            UInt640 dividend = default;
+            dividend.SetBit(2 * polyDeg);
+
+            UInt640 quotient = default;
+
+            int dividendDegree = dividend.Degree;
+
+            while (dividendDegree >= polyDeg)
+            {
+                int shift = dividendDegree - polyDeg;
+                quotient.SetBit(shift);
+                UInt640 polyShifted = default;
+                polyShifted.SetFromUInt128(poly);
+                polyShifted.ShiftLeft(shift);
+                dividend.Xor(ref polyShifted);
+                dividendDegree = dividend.Degree;
+            }
+
+            return quotient.ToUInt64();
+        }
+
+        /// <summary>
+        /// A 640-bit unsigned integer type for GF(2) polynomial arithmetic.
+        /// Represented as 10 ulongs in little-endian order.
+        /// </summary>
+        [InlineArray(Length)]
+        internal struct UInt640
+        {
+            internal const int Length = 10;
+            private ulong _element;
+
+            /// <summary>Gets the degree (position of highest set bit) of this value. Returns -1 if zero.</summary>
+            internal readonly int Degree
+            {
+                get
+                {
+                    for (int i = Length - 1; i >= 0; i--)
+                    {
+                        ulong word = this[i];
+                        if (word != 0)
+                        {
+                            return (i * 64) + (63 - System.Numerics.BitOperations.LeadingZeroCount(word));
+                        }
+                    }
+
+                    return -1;
+                }
+            }
+
+            /// <summary>Sets a single bit at the given position.</summary>
+            internal void SetBit(int position)
+            {
+                int wordIndex = position / 64;
+                int bitIndex = position % 64;
+                Debug.Assert(wordIndex < Length);
+                this[wordIndex] |= 1UL << bitIndex;
+            }
+
+            /// <summary>Initializes from a UInt128 value.</summary>
+            internal void SetFromUInt128(UInt128 value)
+            {
+                this[0] = (ulong)value;
+                this[1] = (ulong)(value >> 64);
+            }
+
+            /// <summary>Shifts all bits left by the given amount.</summary>
+            internal void ShiftLeft(int shift)
+            {
+                Debug.Assert(shift >= 0);
+                if (shift == 0)
+                {
+                    return;
+                }
+
+                int wordShift = shift / 64;
+                int bitShift = shift % 64;
+
+                // Shift words
+                if (wordShift > 0)
+                {
+                    for (int i = Length - 1; i >= 0; i--)
+                    {
+                        this[i] = i >= wordShift ? this[i - wordShift] : 0;
+                    }
+                }
+
+                // Shift bits within words
+                if (bitShift > 0)
+                {
+                    for (int i = Length - 1; i > 0; i--)
+                    {
+                        this[i] = (this[i] << bitShift) | (this[i - 1] >> (64 - bitShift));
+                    }
+
+                    this[0] <<= bitShift;
+                }
+            }
+
+            /// <summary>XORs this value with another.</summary>
+            internal void Xor(ref UInt640 other)
+            {
+                for (int i = 0; i < Length; i++)
+                {
+                    this[i] ^= other[i];
+                }
+            }
+
+            /// <summary>Extracts the low 64 bits.</summary>
+            internal readonly ulong ToUInt64() => this[0];
+
+        }
+    }
+}
+
+#endif


### PR DESCRIPTION
Remaining Follow-up Items

   1. Reflected CRC-64 vectorization — Currently falls back to scalar. The reflected CRC-64 constants require 65-bit reflection width (reflect(value, 65)), which
  overflows a ulong. Solving this requires either widening the constant computation to UInt128, or a mathematical shortcut that avoids reflecting 65-bit values. No known
   users of reflected CRC-64 exist in the test suite today (CRC-64/XZ and CRC-64/GO-ISO are reflected, but not yet added as test drivers).
   2. Performance benchmarking — The implementation is functionally correct but hasn't been benchmarked. Need BenchmarkDotNet comparisons of scalar vs vectorized for
  various input sizes, and comparison of the parameterized vectorization vs the hardcoded Crc32.Vectorized.cs / Crc64.Vectorized.cs to measure any overhead from
  runtime-computed constants.
   3. ARM vectorization threshold tuning — The hardcoded Crc64.Vectorized.cs uses a higher minimum threshold on ARM (256 bytes vs 16 bytes on x86) due to the shuffle
  cost of emulating PCLMULQDQ via AES instructions. The parameterized implementations currently use 16 bytes universally. May need a platform-specific threshold.